### PR TITLE
Serial Interface + Realistic Keyboard + Reset Button + Fixed Via Interrupts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Java 6502 Emulator
 
+## Update: v2.10: Realistic Keyboard, Serial Emulation, and more command line args!
+What an update! Thanks to lythd, the emulator now supports a realistic PS/2-like keyboard mode that can be enabled in the options pane. They've also added a serial emulator that can be turned on in a separate window for testing out programs like Wozmon. It's super cool!
+
+We've also added some new command line arguments:
+- `-windowWidth <int>` and `windowHeight <int>` do what they say on the tin, and should be a welcome change for those of you with differently sized monitors.
+- `-f <path to ROM file>` will pre-load the ROM with the file specified. I finally got around to adding this one, and I hope you find it useful.
+
+I'd also like to take this opportunity to note that this repo is showing its age. The code is an absolute mess since I wrote it back in high school, and I'd like to take some time to completely rewrite it from the ground up using actual OOP instead of the mess of magic numbers and duplicated function calls that builds the Swing UI.<br>
+It will be a big undertaking, but seeing how popular this repo is getting I'm sure everyone would appreciate it.
+
+(still) Coming soon!:
+- Complete code refactor
+- Other 65C02 instructions
+- More bug fixes
+
 ## Update: v2.9: ACIA and Command line options!
 Thanks to Steve Rubin, the emulator now supports ACIA communication through the command line! Like the VIA, the ACIA's address can be adjusted in the options menu.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Java 6502 Emulator
 
 ## Update: v2.10: Realistic Keyboard, Serial Emulation, and more command line args!
-What an update! Thanks to lythd, the emulator now supports a realistic PS/2-like keyboard mode that can be enabled in the options pane. They've also added a serial emulator that can be turned on in a separate window for testing out programs like Wozmon. It's super cool!
+What an update! Thanks to lythd, the emulator now supports a realistic PS/2-like keyboard mode that can be enabled in the options pane. They've also added a serial emulator that can be turned on in a separate window. It's super cool!
+
+Note that Wozmon is not running correctly through this serial interface yet, but we are working on the issue and will update when it's fixed.
 
 We've also added some new command line arguments:
 - `-windowWidth <int>` and `windowHeight <int>` do what they say on the tin, and should be a welcome change for those of you with differently sized monitors.
@@ -11,9 +13,9 @@ I'd also like to take this opportunity to note that this repo is showing its age
 It will be a big undertaking, but seeing how popular this repo is getting I'm sure everyone would appreciate it.
 
 (still) Coming soon!:
+- More bug fixes, Wozmon
 - Complete code refactor
 - Other 65C02 instructions
-- More bug fixes
 
 ## Update: v2.9: ACIA and Command line options!
 Thanks to Steve Rubin, the emulator now supports ACIA communication through the command line! Like the VIA, the ACIA's address can be adjusted in the options menu.

--- a/src/ACIA.java
+++ b/src/ACIA.java
@@ -33,24 +33,9 @@ public class ACIA {
 
 		switch (Short.toUnsignedInt(address) - Bus.ACIA_ADDRESS) {
 			case 0x00:
-				try {
-						DATA = (byte) System.in.read();
-						if (DATA == 0xa) DATA = 0xd; //convert \n to \r
-					
-				} catch (Exception e) {
-					System.err.println("Error reading from System.in");
-				}
-				return DATA; // Read Receiver Data Register
+				return EaterEmulator.serial.getKey(); // get serial key
 			case 0x01:
-			try	 {
-								if (System.in.available() >= 1) {  // TODO: Remove this later when we go to a windowed interface
-					STATUS = 1 << 3;
-				} else {
-					STATUS = 0 << 3;
-				}
-			} catch (Exception e) {
-				System.err.println("Error reading from System.in");
-			}
+				STATUS = (byte) (EaterEmulator.serial.hasKey() ? 0x08 : 0x00);
 				return STATUS; // Read Status Register
 			case 0x02:
 				return COMMAND; // Read Command Register
@@ -67,12 +52,15 @@ public class ACIA {
 	public void write(short address, byte data) {
 		switch (Short.toUnsignedInt(address) - Bus.ACIA_ADDRESS) {
 			case 0x00:
-				System.out.printf("%c", data); // Write Transmitter Data Register
-				if (data == 0xd) System.out.printf("\n"); // convert \r to \n
+				if (data != 0xd) EaterEmulator.serial.receiveKey(data); // discard \r so its just \n, send to serial interface
 
 			case 0x01: // Programmed Reset
 							// Clear bits 4 through 0 in the Command Register and bit 2 in the Status
 							// Register
+				//COMMAND &= 0b11100000;
+				//STATUS &= 0b11111011; //i dont remember this but just doing what was written
+				//EaterEmulator.serial.reset();
+				//okay this is triggering in some random places and im kinda confused why so ill just leave it empty like how it was before
 			case 0x02:
 				COMMAND = data;
 				break; // Write Command Register

--- a/src/Bus.java
+++ b/src/Bus.java
@@ -8,6 +8,7 @@ public class Bus {
 		} else if (Short.toUnsignedInt(address) <= VIA_ADDRESS+16 && Short.toUnsignedInt(address) >= VIA_ADDRESS) {
 			return EaterEmulator.via.read(address);
 		} else if (Short.toUnsignedInt(address) <= ACIA_ADDRESS+3 && Short.toUnsignedInt(address) >= ACIA_ADDRESS) {
+			if (EaterEmulator.verbose) System.out.println("Read from address "+Integer.toHexString(Short.toUnsignedInt(address)));
 			return EaterEmulator.acia.read(address);
 		} else {
 			return EaterEmulator.ram.read(address);
@@ -21,9 +22,10 @@ public class Bus {
 			EaterEmulator.via.write(address, data);
 		} else if (Short.toUnsignedInt(address) <= ACIA_ADDRESS+3 && Short.toUnsignedInt(address) >= ACIA_ADDRESS) {
 			EaterEmulator.acia.write(address, data);
+			if (EaterEmulator.verbose) System.out.println("Wrote "+ROMLoader.byteToHexString(data)+" at "+Integer.toHexString(Short.toUnsignedInt(address)));
 		} else {
 			EaterEmulator.ram.write(address, data);
 		}
-		//if (EaterEmulator.verbose) System.out.println("Wrote "+data+" at "+address);
+		
 	}
 }

--- a/src/CPU.java
+++ b/src/CPU.java
@@ -624,6 +624,9 @@ public class CPU {
 	
 	//Input Signal Handlers
 	void reset() {
+		EaterEmulator.clockState = false;
+		if (EaterEmulator.serial != null) EaterEmulator.serial.reset();
+		
 		a = 0;
 		x = 0;
 		y = 0;

--- a/src/DisplayPanel.java
+++ b/src/DisplayPanel.java
@@ -3,6 +3,7 @@ import java.awt.event.*;
 import javax.swing.JPanel;
 import javax.swing.Timer;
 import java.io.IOException;
+import java.util.ArrayList;
 
 public class DisplayPanel extends JPanel implements ActionListener, KeyListener {
 	Timer frameTimer = new javax.swing.Timer(16, this);;
@@ -19,6 +20,10 @@ public class DisplayPanel extends JPanel implements ActionListener, KeyListener 
 
 	public static Color bgColor = Color.blue;
 	public static Color fgColor = Color.white;
+	
+	public static ArrayList<Byte> keys = new ArrayList<Byte>();
+	
+	boolean debug = false;
 	
 	public DisplayPanel() {
 		super(null);
@@ -167,11 +172,13 @@ public class DisplayPanel extends JPanel implements ActionListener, KeyListener 
 			EaterEmulator.RAMopenButton.setBounds(rightAlignHelper-150, 45, 125, 25);
 			EaterEmulator.ShowLCDButton.setBounds(rightAlignHelper-300, 15, 125, 25);
 			EaterEmulator.ShowGPUButton.setBounds(rightAlignHelper-300, 45, 125, 25);
-			EaterEmulator.optionsButton.setBounds(rightAlignHelper-450, 15, 125, 25);
-			EaterEmulator.keyboardButton.setBounds(rightAlignHelper-450, 45, 125, 25);
+			EaterEmulator.ResetButton.setBounds(rightAlignHelper-450, 15, 125, 25);
+			EaterEmulator.ShowSerialButton.setBounds(rightAlignHelper-450, 45, 125, 25);
+			EaterEmulator.optionsButton.setBounds(rightAlignHelper-600, 15, 125, 25);
+			EaterEmulator.keyboardButton.setBounds(rightAlignHelper-600, 45, 125, 25);
 			this.repaint();
 
-			if (!EaterEmulator.options.isVisible())
+			if (!EaterEmulator.options.isVisible() && !EaterEmulator.serial.isVisible())
 				this.requestFocus();
 		} else if (e.getSource().equals(clocksPerSecondCheckTimer)) {
 			EaterEmulator.cpu.timeDelta = System.nanoTime()-EaterEmulator.cpu.lastTime;
@@ -186,12 +193,21 @@ public class DisplayPanel extends JPanel implements ActionListener, KeyListener 
 
 	@Override
 	public void keyPressed(KeyEvent arg0) {
-		
+		if (EaterEmulator.keyboardMode && EaterEmulator.realisticKeyboard) {
+			keys.add(convertToPs2(arg0));
+			if(EaterEmulator.verbose&&debug) System.out.println("Pressed key " + arg0.getKeyChar() + " " + convertToPs2(arg0) + " : " + (arg0.getKeyCode()));
+			EaterEmulator.via.CA1();
+		}
 	}
 
 	@Override
 	public void keyReleased(KeyEvent arg0) {
-		
+		if (EaterEmulator.keyboardMode && EaterEmulator.realisticKeyboard) {
+			keys.add((byte) 0xf0);
+			keys.add(convertToPs2(arg0));
+			if(EaterEmulator.verbose&&debug) System.out.println("Pressed key " + arg0.getKeyChar() + " " + convertToPs2(arg0) + " : " + (arg0.getKeyCode()));
+			EaterEmulator.via.CA1();
+		}
 	}
 
 	@Override
@@ -257,10 +273,240 @@ public class DisplayPanel extends JPanel implements ActionListener, KeyListener 
 					EaterEmulator.via.CA1();
 					break;
 			}
-		} else {
+		} else if (!EaterEmulator.realisticKeyboard) { //realistic keyboard uses key pressed and released so it can get the key code
 			//Typing Keyboard Mode
 			Bus.write((short)EaterEmulator.options.data.keyboardLocation, (byte)arg0.getKeyChar());
 			EaterEmulator.via.CA1();
 		}
+	}
+
+	
+	//converts java keyCode to ps2 keyCode to be compatible
+	//found https://techdocs.altium.com/display/FPGA/PS2+Keyboard+Scan+Codes
+	private byte convertToPs2(KeyEvent keyEvent) {
+		switch(keyEvent.getKeyCode()) {
+		case KeyEvent.VK_ESCAPE:
+			return 0x76;
+		case KeyEvent.VK_F1:
+			return 0x05;
+		case KeyEvent.VK_F2:
+			return 0x06;
+		case KeyEvent.VK_F3:
+			return 0x04;
+		case KeyEvent.VK_F4:
+			return 0x0C;
+		case KeyEvent.VK_F5:
+			return 0x03;
+		case KeyEvent.VK_F6:
+			return 0x0B;
+		case KeyEvent.VK_F7:
+			return (byte) 0x83;
+		case KeyEvent.VK_F8:
+			return 0x0A;
+		case KeyEvent.VK_F9:
+			return 0x01;
+		case KeyEvent.VK_F10:
+			return 0x09;
+		case KeyEvent.VK_F11:
+			return 0x78;
+		case KeyEvent.VK_F12:
+			return 0x07;
+		case KeyEvent.VK_SCROLL_LOCK:
+			return 0x7E;
+		case KeyEvent.VK_DEAD_GRAVE:
+			return 0x0E;
+		case KeyEvent.VK_BACK_QUOTE:
+			return 0x0E;
+		case KeyEvent.VK_1:
+			return 0x16;
+		case KeyEvent.VK_2:
+			return 0x1E;
+		case KeyEvent.VK_3:
+			return 0x26;
+		case KeyEvent.VK_4:
+			return 0x25;
+		case KeyEvent.VK_5:
+			return 0x2E;
+		case KeyEvent.VK_6:
+			return 0x36;
+		case KeyEvent.VK_7:
+			return 0x3D;
+		case KeyEvent.VK_8:
+			return 0x3E;
+		case KeyEvent.VK_9:
+			return 0x46;
+		case KeyEvent.VK_0:
+			return 0x45;
+		case KeyEvent.VK_MINUS:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_NUMPAD) return 0x7B;
+			else return 0x4E;
+		case KeyEvent.VK_UNDERSCORE:
+			return 0x4E;
+		case KeyEvent.VK_EQUALS:
+			return 0x55;
+		case KeyEvent.VK_PLUS:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_NUMPAD) return 0x79;
+			else return 0x55;
+		case KeyEvent.VK_BACK_SPACE:
+			return 0x66;
+		case KeyEvent.VK_TAB:
+			return 0x0D;
+		case KeyEvent.VK_Q:
+			return 0x15;
+		case KeyEvent.VK_W:
+			return 0x1D;
+		case KeyEvent.VK_E:
+			return 0x24;
+		case KeyEvent.VK_R:
+			return 0x2D;
+		case KeyEvent.VK_T:
+			return 0x2C;
+		case KeyEvent.VK_Y:
+			return 0x35;
+		case KeyEvent.VK_U:
+			return 0x3C;
+		case KeyEvent.VK_I:
+			return 0x43;
+		case KeyEvent.VK_O:
+			return 0x44;
+		case KeyEvent.VK_P:
+			return 0x4D;
+		case KeyEvent.VK_OPEN_BRACKET:
+			return 0x54;
+		case KeyEvent.VK_BRACELEFT:
+			return 0x54;
+		case KeyEvent.VK_CLOSE_BRACKET:
+			return 0x5B;
+		case KeyEvent.VK_BRACERIGHT:
+			return 0x5B;
+		case KeyEvent.VK_BACK_SLASH:
+			return 0x5D;
+		case KeyEvent.VK_CAPS_LOCK:
+			return 0x58;
+		case KeyEvent.VK_A:
+			return 0x1C;
+		case KeyEvent.VK_S:
+			return 0x1B;
+		case KeyEvent.VK_D:
+			return 0x23;
+		case KeyEvent.VK_F:
+			return 0x2B;
+		case KeyEvent.VK_G:
+			return 0x34;
+		case KeyEvent.VK_H:
+			return 0x33;
+		case KeyEvent.VK_J:
+			return 0x3B;
+		case KeyEvent.VK_K:
+			return 0x32;
+		case KeyEvent.VK_L:
+			return 0x4B;
+		case KeyEvent.VK_SEMICOLON:
+			return 0x4C;
+		case KeyEvent.VK_COLON:
+			return 0x4C;
+		case KeyEvent.VK_QUOTE:
+			return 0x52;
+		case KeyEvent.VK_QUOTEDBL:
+			return 0x52;
+		case KeyEvent.VK_ENTER:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_NUMPAD) return 0x5A;
+			else return 0x5A;
+		case KeyEvent.VK_SHIFT:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_RIGHT) return 0x59;
+			else return 0x12;
+		case KeyEvent.VK_Z:
+			return 0x1A;
+		case KeyEvent.VK_X:
+			return 0x22;
+		case KeyEvent.VK_C:
+			return 0x21;
+		case KeyEvent.VK_V:
+			return 0x2A;
+		case KeyEvent.VK_B:
+			return 0x32;
+		case KeyEvent.VK_N:
+			return 0x31;
+		case KeyEvent.VK_M:
+			return 0x3A;
+		case KeyEvent.VK_COMMA:
+			return 0x41;
+		case KeyEvent.VK_LESS:
+			return 0x41;
+		case KeyEvent.VK_PERIOD:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_NUMPAD) return 0x71;
+			else return 0x49;
+		case KeyEvent.VK_GREATER:
+			return 0x49;
+		case KeyEvent.VK_SLASH:
+			return 0x4A;
+		case KeyEvent.VK_CONTROL:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_RIGHT) return 0x14;
+			else return 0x14;
+		case KeyEvent.VK_WINDOWS:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_RIGHT) return 0x27;
+			else return 0x1F;
+		case KeyEvent.VK_ALT:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_RIGHT) return 0x11;
+			else return 0x11;
+		case KeyEvent.VK_SPACE:
+			return 0x29;
+		case KeyEvent.VK_CONTEXT_MENU:
+			return 0x2F;
+		case KeyEvent.VK_INSERT:
+			return 0x70;
+		case KeyEvent.VK_HOME:
+			return 0x6C;
+		case KeyEvent.VK_PAGE_UP:
+			return 0x7D;
+		case KeyEvent.VK_DELETE:
+			return 0x71;
+		case KeyEvent.VK_END:
+			return 0x69;
+		case KeyEvent.VK_PAGE_DOWN:
+			return 0x7A;
+		case KeyEvent.VK_UP:
+			return 0x75;
+		case KeyEvent.VK_KP_UP:
+			return 0x75;
+		case KeyEvent.VK_LEFT:
+			return 0x6B;
+		case KeyEvent.VK_KP_LEFT:
+			return 0x6B;
+		case KeyEvent.VK_DOWN:
+			return 0x72;
+		case KeyEvent.VK_KP_DOWN:
+			return 0x72;
+		case KeyEvent.VK_RIGHT:
+			return 0x74;
+		case KeyEvent.VK_KP_RIGHT:
+			return 0x74;
+		case KeyEvent.VK_NUM_LOCK:
+			return 0x77;
+		case KeyEvent.VK_ASTERISK:
+			if(keyEvent.getKeyLocation() == KeyEvent.KEY_LOCATION_NUMPAD) return 0x7C;
+			else return 0x3E;
+		case KeyEvent.VK_NUMPAD1:
+			return 0x69;
+		case KeyEvent.VK_NUMPAD2:
+			return 0x72;
+		case KeyEvent.VK_NUMPAD3:
+			return 0x7A;
+		case KeyEvent.VK_NUMPAD4:
+			return 0x6B;
+		case KeyEvent.VK_NUMPAD5:
+			return 0x73;
+		case KeyEvent.VK_NUMPAD6:
+			return 0x74;
+		case KeyEvent.VK_NUMPAD7:
+			return 0x6C;
+		case KeyEvent.VK_NUMPAD8:
+			return 0x75;
+		case KeyEvent.VK_NUMPAD9:
+			return 0x7D;
+		case KeyEvent.VK_NUMPAD0:
+			return 0x70;
+		}
+		return 0;
 	}
 }

--- a/src/DisplayPanel.java
+++ b/src/DisplayPanel.java
@@ -68,7 +68,7 @@ public class DisplayPanel extends JPanel implements ActionListener, KeyListener 
         
         //Version
         g.setFont(courierNewBold);
-        g.drawString("v"+EaterEmulator.versionString+" (c) Dylan Speiser", 7, 1033);
+        g.drawString("v"+EaterEmulator.versionString, 7, 1033);
         
         //Clocks
         g.drawString("Clocks: "+EaterEmulator.clocks, 40, 80);

--- a/src/EaterEmulator.java
+++ b/src/EaterEmulator.java
@@ -213,7 +213,6 @@ public class EaterEmulator extends JFrame implements ActionListener {
 				for (int i = 0; i < args.length; i++) {
 					String s = args[i];
 					if (s.equals("-verbose")) verbose = true;
-					else if (s.equals("-realisticKeyboard")) realisticKeyboard = true;
 					else if (s.equals("-windowWidth")) {
 						try {
 							windowWidth = Integer.parseInt(args[++i]);
@@ -228,11 +227,21 @@ public class EaterEmulator extends JFrame implements ActionListener {
 							System.out.println("Window height not understood, defaulting to " + windowHeight);
 						}
 					}
+					else if (s.equals("-f")) {
+						try {
+							rom.setROMArray(ROMLoader.readROM(new File(args[++i])));
+				        
+					        GraphicsPanel.requestFocus();
+					        GraphicsPanel.romPageString = EaterEmulator.rom.ROMString.substring(GraphicsPanel.romPage*960,(GraphicsPanel.romPage+1)*960);
+							cpu.reset();
+						} catch (Exception e) {
+							System.out.println("There was an error loading the ROM file specified with -f");
+						}
+					}
 				}
 				
 				//printing done after all arguments incase verbose argument comes after the other arguments
 				if (verbose) System.out.println("Running in verbose mode!");
-				if (verbose&&realisticKeyboard) System.out.println("Realistic keyboard enabled!");
 				if (verbose) System.out.println("Resolution of " + windowWidth + "x" + windowHeight + ".");
 				
 				emu = new EaterEmulator();

--- a/src/EaterEmulator.java
+++ b/src/EaterEmulator.java
@@ -8,10 +8,12 @@ import java.io.File;
 import javax.swing.*;
 
 public class EaterEmulator extends JFrame implements ActionListener {
-	public static String versionString = "2.9";
+	public static String versionString = "2.10";
 	public static boolean debug = false;
 
 	public static boolean verbose = false;
+	public static boolean realisticKeyboard = false;
+	public static int windowWidth = 1920, windowHeight = 1080;
 	
 	//Swing Things
 	JPanel p = new JPanel();
@@ -20,8 +22,10 @@ public class EaterEmulator extends JFrame implements ActionListener {
 	public static JButton ROMopenButton = new JButton("Open ROM File");
 	public static JButton RAMopenButton = new JButton("Open RAM File");
 
-	public static JButton ShowLCDButton = new JButton("Hide LCD");
+	public static JButton ShowLCDButton = new JButton("Show LCD");
 	public static JButton ShowGPUButton = new JButton("Show GPU");
+	public static JButton ShowSerialButton = new JButton("Show Serial");
+	public static JButton ResetButton = new JButton("Reset");
 
 	public static JButton optionsButton = new JButton("Options");
 	public static JButton keyboardButton= new JButton("Keyboard Mode");
@@ -45,13 +49,14 @@ public class EaterEmulator extends JFrame implements ActionListener {
 	public static Bus bus = new Bus();
 	public static CPU cpu = new CPU();
 	public static GPU gpu = new GPU(ram,false);
+	public static SerialInterface serial = new SerialInterface(false);
 	public static DisplayPanel GraphicsPanel = new DisplayPanel();
 	public static OptionsPane options = new OptionsPane();
 	
 	public EaterEmulator() {
 		//Swing Stuff:
 		System.setProperty("sun.java2d.opengl", "true");
-		this.setSize(1920,1080);
+		this.setSize(windowWidth, windowHeight);
 		try {
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
 		}catch(Exception ex) {
@@ -83,18 +88,30 @@ public class EaterEmulator extends JFrame implements ActionListener {
 		ShowGPUButton.setBounds(getWidth()-300, 45, 125, 25);
 		ShowGPUButton.setBackground(Color.white);
 		GraphicsPanel.add(ShowGPUButton);
+		
+		ShowSerialButton.setVisible(true);
+		ShowSerialButton.addActionListener(this);
+		ShowSerialButton.setBounds(getWidth()-450, 15, 125, 25);
+		ShowSerialButton.setBackground(Color.white);
+		GraphicsPanel.add(ShowSerialButton);
+		
+		ResetButton.setVisible(true);
+		ResetButton.addActionListener(this);
+		ResetButton.setBounds(getWidth()-450, 45, 125, 25);
+		ResetButton.setBackground(Color.white);
+		GraphicsPanel.add(ResetButton);
 
 		//Options Button
 		optionsButton.setVisible(true);
 		optionsButton.addActionListener(this);
-		optionsButton.setBounds(getWidth()-450, 15, 125, 25);
+		optionsButton.setBounds(getWidth()-600, 15, 125, 25);
 		optionsButton.setBackground(Color.white);
 		GraphicsPanel.add(optionsButton);
 
 		//Keyboard Mode Button
 		keyboardButton.setVisible(true);
 		keyboardButton.addActionListener(this);
-		keyboardButton.setBounds(getWidth()-450, 45, 125, 25);
+		keyboardButton.setBounds(getWidth()-600, 45, 125, 25);
 		keyboardButton.setBackground(Color.white);
 		GraphicsPanel.add(keyboardButton);
 		
@@ -159,6 +176,10 @@ public class EaterEmulator extends JFrame implements ActionListener {
 			lcd.setVisible(!lcd.isVisible());
 		} else if (e.getSource().equals(ShowGPUButton)) {
 			gpu.setVisible(!gpu.isVisible());
+		} else if (e.getSource().equals(ShowSerialButton)) {
+			serial.setVisible(!serial.isVisible());
+		} else if (e.getSource().equals(ResetButton)) {
+			cpu.reset();
 		} else if (e.getSource().equals(optionsButton)) {
 			options.setVisible(!options.isVisible());
 		} else if (e.getSource().equals(GraphicsPanel.frameTimer)) {
@@ -173,6 +194,12 @@ public class EaterEmulator extends JFrame implements ActionListener {
 			} else {
 				ShowLCDButton.setText("Hide LCD");
 			}
+
+			if (!serial.isVisible()) {
+				ShowSerialButton.setText("Show Serial");
+			} else {
+				ShowSerialButton.setText("Hide Serial");
+			}
 		} else if (e.getSource().equals(keyboardButton)) {
 			keyboardMode = !keyboardMode;
 		}
@@ -183,13 +210,32 @@ public class EaterEmulator extends JFrame implements ActionListener {
 	public static void main(String[] args) {
 		javax.swing.SwingUtilities.invokeLater(new Runnable() {
             public void run() {
-				emu = new EaterEmulator();
-
-				for (String s : args) {
-					if (s.equals("-verbose"))
-						verbose = true;
-						System.out.println("Running in verbose mode!");
+				for (int i = 0; i < args.length; i++) {
+					String s = args[i];
+					if (s.equals("-verbose")) verbose = true;
+					else if (s.equals("-realisticKeyboard")) realisticKeyboard = true;
+					else if (s.equals("-windowWidth")) {
+						try {
+							windowWidth = Integer.parseInt(args[++i]);
+						} catch (Exception e) {
+							System.out.println("Window width not understood, defaulting to " + windowWidth);
+						}
+					}
+					else if (s.equals("-windowHeight")) {
+						try {
+							windowHeight = Integer.parseInt(args[++i]);
+						} catch (Exception e) {
+							System.out.println("Window height not understood, defaulting to " + windowHeight);
+						}
+					}
 				}
+				
+				//printing done after all arguments incase verbose argument comes after the other arguments
+				if (verbose) System.out.println("Running in verbose mode!");
+				if (verbose&&realisticKeyboard) System.out.println("Realistic keyboard enabled!");
+				if (verbose) System.out.println("Resolution of " + windowWidth + "x" + windowHeight + ".");
+				
+				emu = new EaterEmulator();
             }
         });
 	}

--- a/src/OptionsData.java
+++ b/src/OptionsData.java
@@ -18,6 +18,7 @@ public class OptionsData implements Serializable {
     int GPUMode = GPU.gpuMode;
     int GPUBitmapPixelScale = GPU.GPUPixelScale;
     int keyboardLocation = 0x3fff;
+    int keyboardMode = 0;
     boolean lcdBigMode = false;
     Color bgColor = Color.blue;
 	Color fgColor = Color.white;
@@ -34,6 +35,7 @@ public class OptionsData implements Serializable {
         "GPU Mode: "+GPUMode+"\n"+
         "GPU Bitmap Pixel Scale: "+GPUBitmapPixelScale+"\n"+
         "Keyboard Memory Location: "+keyboardLocation+"\n"+
+        "Keyboard Mode: "+keyboardMode+"\n"+
         "LCD Mode: "+(lcdBigMode ? "20x4" : "16x2")+"\n"+
         "Background Color: "+bgColor.toString()+"\n"+
         "Foreground Color: "+fgColor.toString()+"\n";

--- a/src/OptionsPane.java
+++ b/src/OptionsPane.java
@@ -70,6 +70,10 @@ public class OptionsPane extends JFrame implements ActionListener {
     JTextField KeyboardLocationTextField = new JTextField(""+data.keyboardLocation);
     JLabel KeyboardLocationHexLabel = new JLabel(Integer.toHexString(data.GPUBufferBegin));
 
+    JLabel KeyboardModeOptionLabel = new JLabel("Keyboard Mode");
+    JTextField KeyboardModeOptionTextField = new JTextField(""+data.keyboardMode);
+    JLabel KeyboardModeExplanationLabel = new JLabel("<html>Keyboard Mode 0 = Simplified Keyboard Mode<br>Keyboard Mode 1 = Realistic Keyboard Mode</html>");
+
     JLabel ForegroundColorLabel = new JLabel("Foreground Color");
     JTextField ForegroundColorChooser = new JTextField("#"+Integer.toHexString(data.fgColor.getRGB()).substring(2));
 
@@ -84,7 +88,7 @@ public class OptionsPane extends JFrame implements ActionListener {
     JButton saveOptionsButton = new JButton("Save Options to File");
 	
 	public OptionsPane() {
-		this.setSize(700,730);
+		this.setSize(700,750);
 		t = new Timer(16,this);
 		t.start();
 
@@ -141,6 +145,9 @@ public class OptionsPane extends JFrame implements ActionListener {
         SwingComponentsList.add(KeyboardLocationLabel);
         SwingComponentsList.add(KeyboardLocationTextField);
         SwingComponentsList.add(KeyboardLocationHexLabel);
+        SwingComponentsList.add(KeyboardModeOptionLabel);
+        SwingComponentsList.add(KeyboardModeOptionTextField);
+        SwingComponentsList.add(KeyboardModeExplanationLabel);
         SwingComponentsList.add(LCDModeLabel);
         SwingComponentsList.add(LCDModeRadioLarge);
         SwingComponentsList.add(LCDModeRadioSmall);
@@ -374,6 +381,7 @@ public class OptionsPane extends JFrame implements ActionListener {
         data.bgColor = Color.decode(BackgroundColorChooser.getText());
         data.GPUBitmapPixelScale = Integer.parseInt(GPUBitmapPixelScaleTextField.getText());
         data.keyboardLocation = Integer.parseInt(KeyboardLocationTextField.getText());
+        data.keyboardMode = Integer.parseInt(KeyboardModeOptionTextField.getText());
 
         Bus.VIA_ADDRESS = data.VIA_Address;
         Bus.ACIA_ADDRESS = data.ACIA_Address;
@@ -402,6 +410,8 @@ public class OptionsPane extends JFrame implements ActionListener {
         data.lcdBigMode = LCDModeRadioLarge.isSelected();
         EaterEmulator.lcd.bigMode = data.lcdBigMode;
         EaterEmulator.lcd.updateMode();
+
+        EaterEmulator.realisticKeyboard = (data.keyboardMode == 1);
     }
 
     private void resetSwingPositions() {
@@ -443,21 +453,25 @@ public class OptionsPane extends JFrame implements ActionListener {
 
         GPUModeExplanationLabel.setBounds(175,370,500,100);
 
-        KeyboardLocationLabel.setBounds(125,470,175,25);
+        KeyboardLocationLabel.setBounds(120,470,185,25);
         KeyboardLocationTextField.setBounds(300,470,100,25);
         KeyboardLocationHexLabel.setBounds(400,470,100,25);
+        
+        KeyboardModeOptionLabel.setBounds(180,500,175,25);
+        KeyboardModeOptionTextField.setBounds(300,500,25,25);
+        KeyboardModeExplanationLabel.setBounds(175,520,500,60);
 
-        LCDModeLabel.setBounds(225,510,75,25);
-        LCDModeRadioSmall.setBounds(300,510,100,25);
-        LCDModeRadioLarge.setBounds(400,510,100,25);
+        LCDModeLabel.setBounds(225,580,75,25);
+        LCDModeRadioSmall.setBounds(300,580,100,25);
+        LCDModeRadioLarge.setBounds(400,580,100,25);
 
-        ForegroundColorLabel.setBounds(175,550,125,25);
-        ForegroundColorChooser.setBounds(300,550,100,25);
+        ForegroundColorLabel.setBounds(175,610,125,25);
+        ForegroundColorChooser.setBounds(300,610,100,25);
 
-        BackgroundColorLabel.setBounds(175,590,125,25);
-        BackgroundColorChooser.setBounds(300,590,100,25);
+        BackgroundColorLabel.setBounds(175,640,125,25);
+        BackgroundColorChooser.setBounds(300,640,100,25);
 
-        applyOptionsButton.setBounds(200,640,150,25);
-        saveOptionsButton.setBounds(350,640,150,25);
+        applyOptionsButton.setBounds(200,690,150,25);
+        saveOptionsButton.setBounds(350,690,150,25);
     }
 }

--- a/src/ROMLoader.java
+++ b/src/ROMLoader.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 public class ROMLoader {
 	static ArrayList<Byte> ROM = new ArrayList<Byte>();
 	
-	//static File ROMfile = new File("C:/Users/Dylan/Documents/vasm workspace/out.bin");
-	
 	public static byte[] readROM(File file) {
 		ROM = new ArrayList<Byte>();
 		

--- a/src/SerialInterface.java
+++ b/src/SerialInterface.java
@@ -1,0 +1,107 @@
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
+public class SerialInterface extends JFrame implements ActionListener {
+
+	private JTextArea textArea;
+	private Byte typedKey = 0x00;
+	private boolean hasKey = false;
+	
+    public SerialInterface(boolean isVisible) {
+        // Set up the frame
+        setTitle("Serial Interface");
+        setSize(400, 300);
+        getContentPane().setBackground(new Color(40, 40, 40)); // Dark gray background
+        getRootPane().setBorder(null);
+
+        // Create a text area for displaying text
+        textArea = new JTextArea();
+        textArea.setEditable(false);
+        textArea.setFont(new Font("Monospaced", Font.PLAIN, 12)); // Set font to monospaced for console-like appearance
+
+        // Set text area colors
+        textArea.setBackground(new Color(40, 40, 40)); // Dark gray background
+        textArea.setForeground(Color.WHITE); // White text color
+        textArea.setCaretColor(Color.WHITE); // White cursor color
+
+        // Disable the text area border
+        textArea.setBorder(null);
+        
+        // Set up a key listener to capture key events
+        textArea.addKeyListener(new KeyListener() {
+            @Override
+            public void keyTyped(KeyEvent e) { }
+
+            @Override
+            public void keyPressed(KeyEvent e) {
+            	if(isAcceptableChar(e.getKeyChar())) { // have to restrict characters like shift from being sent
+	            	hasKey = true;
+	                typedKey = (byte) e.getKeyChar();
+            	}
+            }
+
+            @Override
+            public void keyReleased(KeyEvent e) { }
+        });
+
+        // Set up the layout
+        setLayout(new BorderLayout());
+        add(new JScrollPane(textArea), BorderLayout.CENTER);
+
+        // Make the frame visible
+		this.setAlwaysOnTop(true);
+		this.setVisible(isVisible);
+		this.setDefaultCloseOperation(HIDE_ON_CLOSE);
+        this.setResizable(false);
+    }
+
+    @Override
+    public void setVisible(boolean isVisible) {
+    	super.setVisible(isVisible);
+    	if(isVisible) {
+    		requestFocus();
+    		textArea.requestFocus();
+    	}
+    }
+    
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        repaint();
+    }
+    
+    // Function to get key
+    public byte getKey() {
+        if(!hasKey) return 0x00;
+        hasKey = false;
+    	return typedKey;
+    }
+    
+    // Function to check if key is there
+    public boolean hasKey() {
+    	return hasKey;
+    }
+
+    // Function to receive key
+    public void receiveKey(byte keyChar) {
+        textArea.append(String.valueOf((char)keyChar));
+    }
+
+    // Function to reset the text area
+    public void reset() {
+        textArea.setText("");
+    }
+    
+    private static boolean isAcceptableChar(char c) {
+    	int i = (int)c;
+    	if(i==0x09) return true; //horizontal tab
+    	if(i==0x0a) return true; //enter
+    	if(i==0x1b) return true; //escape
+    	if(i==0x08) return true; //backspace
+    	if(i==0x7f) return true; //delete
+    	return c >= ' ' && c <= '~'; //normal ascii range
+    }
+}

--- a/src/VIA.java
+++ b/src/VIA.java
@@ -15,7 +15,12 @@ public class VIA {
 				return PORTB;
 			case 0x001:
 				IFR &= (byte)(0b01111100);
-				return 0;
+				byte value = 0;
+				if(DisplayPanel.keys.size() > 0 && EaterEmulator.realisticKeyboard) {
+					value = DisplayPanel.keys.get(0);
+					DisplayPanel.keys.remove(0);
+				}
+				return value;
 			case 0x002:
 				return 0;
 			case 0x003:
@@ -60,31 +65,34 @@ public class VIA {
 				IER = data;
 				break;
 		}
+		if(!EaterEmulator.cpu.interruptRequested && DisplayPanel.keys.size() > 0 && EaterEmulator.realisticKeyboard) { //some additional keys, like for release where it sends 2, or maybe two presses really fast
+			CA1();
+		}
 	}
 	
 	public void CA1() {
-		if ((IER &= (byte)(0b00000010)) == 0b00000010) {
+		if ((IER & (byte)(0b00000010)) == 0b00000010) {
 			IFR |= (byte)(0b10000010);
 			EaterEmulator.cpu.interruptRequested = true;
 		}
 	}
 	
 	public void CA2() {
-		if ((IER &= (byte)(0b00000010)) == 0b00000001) {
+		if ((IER & (byte)(0b00000001)) == 0b00000001) {
 			IFR |= (byte)(0b10000001);
 			EaterEmulator.cpu.interruptRequested = true;
 		}
 	}
 	
 	public void CB1() {
-		if ((IER &= (byte)(0b00000010)) == 0b00010000) {
+		if ((IER & (byte)(0b00010000)) == 0b00010000) {
 			IFR |= (byte)(0b10010000);
 			EaterEmulator.cpu.interruptRequested = true;
 		}
 	}
 	
 	public void CB2() {
-		if ((IER &= (byte)(0b00000010)) == 0b00001000) {
+		if ((IER & (byte)(0b00001000)) == 0b00001000) {
 			IFR |= (byte)(0b10001000);
 			EaterEmulator.cpu.interruptRequested = true;
 		}


### PR DESCRIPTION
Serial Interface:
-Accurately reflects the serial interface so it will work like in Ben Eater's video, unlike the java console which has its differences.
-Button to toggle it.
-Code written before will still work.

Realistic Keyboard:
-Accurately reflects the way Ben Eater interacts with the keyboard
-Must be enabled with the `-realisticKeyboard` command line argument, this is so any code written before won't be broken

Reset Button:
-Mainly just added to balance out the number of buttons, but a reset button is handy

Fixed Via Interrupts:
-As I mentioned in the issue I raised there were some issue with the Via interrupt functions, which I fixed

Window Width + Height cmd arguments:
-Added `-windowWidth <int>` and `-windowHeight <int>` command line arguments, just so you don't have to manually resize the window each time if your display isn't 1920x1080

With this code from Ben's series on the keyboard and serial now work, although he never showed implementation of enter, backspace, tab, etc, and those are not automatically handled so watch out for that. (This is accurate to what would happen running on the 65c02).
![image](https://github.com/DylanSpeiser/Java-6502-Emulator/assets/22566088/a6380fce-7cc5-4772-86bc-73a27c4949c7)
