### PR TITLE
Fix ROM toString method

### DIFF
--- a/src/CollectionUtils.java
+++ b/src/CollectionUtils.java
@@ -1,0 +1,21 @@
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+public class CollectionUtils {
+	public static Byte[] toBoxedArray(byte[] array) {
+		return IntStream.range(0, array.length).mapToObj(i -> array[i]).toArray(Byte[]::new);
+	}
+
+	public static <T, R> List<R> mapArray(T[] array, Function<T, R> mapper) {
+		return Arrays.stream(array).map(mapper).toList();
+	}
+
+	public static <T> List<IndexedValue<T>> withIndex(List<T> list) {
+		return IntStream.range(0, list.size()).mapToObj(i -> new IndexedValue<>(i, list.get(i))).toList();
+	}
+
+	public record IndexedValue<T>(int index, T value) {
+	}
+}


### PR DESCRIPTION
I noticed a little bug in the toString method while writing tests.

The method will always add a new line even if there's only one line to output. Ended up majorly rewriting the whole method 😅 

In essence it still does the same but uses some of the java 21 tools to make the code a bit cleaner. 

The method first splits the data into "chunks" each representing the data for one line and then formats each line with the address if required.

toString also now calls toStringWithOffset with a 0 offset, so no duplicated implementation